### PR TITLE
docs: rewrite README to describe the Wellms LMS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,69 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Wellms Frontend
+
+A student-facing Learning Management System (LMS) built with Next.js 16 and React 19. Students can browse and enroll in courses, track their progress, consume diverse content types, and download completion certificates.
+
+## Features
+
+- **Course catalogue** — search by title and filter by category
+- **Course detail pages** — description, curriculum overview, author info, and one-click free enrollment
+- **Topic player** — supports Video, Audio, Rich Text, Images, PDF, H5P, SCORM, and OEmbed content
+- **Progress tracking** — per-topic completion with auto-advance and sidebar navigation
+- **Dashboard** — enrolled courses with progress percentages and quick resume
+- **Certificates** — completion screen with PDF download
+- **Authentication** — register, login, forgot/reset password
+- **Profile management** — avatar upload, personal details, password change
+
+## Tech Stack
+
+| | |
+|---|---|
+| Framework | Next.js 16 (App Router) |
+| UI | React 19, Tailwind CSS v4 |
+| Language | TypeScript 5 |
+| Backend SDK | [@escolalms/sdk](https://github.com/EscolaLMS/sdk) |
+| Testing | Jest 30, React Testing Library |
+| Linting | ESLint 9 |
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Command | Description |
+|---|---|
+| `npm run dev` | Start development server |
+| `npm run build` | Production build |
+| `npm run start` | Start production server |
+| `npm run lint` | Run ESLint |
+| `npm test` | Run tests |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests with coverage report |
 
-## Learn More
+## Project Structure
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```
+app/
+  components/        # Shared UI components
+  courses/
+    [id]/            # Course detail page
+      topics/[topicId]/  # Topic player
+      complete/      # Certificate page
+  dashboard/         # User's enrolled courses
+  profile/           # Account settings
+  register/          # Registration
+  forgot-password/   # Password recovery
+__tests__/           # Jest test files
+```


### PR DESCRIPTION
## Summary

- Replaces the default `create-next-app` boilerplate README with an accurate description of the Wellms LMS frontend
- Documents all main features (course catalogue, topic player, progress tracking, certificates, auth, profile)
- Adds tech stack table, npm scripts reference, and project file structure

## Test plan

- [ ] Review README renders correctly on GitHub
- [ ] Verify all described features match the actual codebase