### PR TITLE
feat: LMS feature parity — focus mode, search page, toast notifications

### DIFF
--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -47,6 +47,18 @@ export function Nav() {
 
         {/* Desktop nav */}
         <div className="hidden sm:flex items-center gap-4">
+          <Link
+            href="/search"
+            aria-label="Search courses"
+            className={`text-sm transition-colors ${
+              pathname === "/search" ? "text-[#1abc9c]" : "text-[#555555] hover:text-[#1abc9c]"
+            }`}
+          >
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="8.5" cy="8.5" r="5.5" />
+              <line x1="13.5" y1="13.5" x2="18" y2="18" />
+            </svg>
+          </Link>
           {loggedIn ? (
             <>
               <Link
@@ -139,6 +151,9 @@ export function Nav() {
                 </div>
                 <p className="text-sm font-semibold text-[#04323e] truncate">{u?.first_name || u?.email}</p>
               </div>
+              <Link href="/search" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
+                Search courses
+              </Link>
               <Link href="/dashboard" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
                 My courses
               </Link>
@@ -160,6 +175,9 @@ export function Nav() {
               >
                 Sign in
               </button>
+              <Link href="/search" className="text-center text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
+                Search courses
+              </Link>
               <Link href="/register" className="text-center text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
                 Create account
               </Link>

--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { CourseCurriculum } from "../../components/CourseCurriculum";
+import { useToast } from "../../components/Toast";
 import type { API } from "@escolalms/sdk/lib";
 
 function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
@@ -29,6 +30,7 @@ export default function CoursePage() {
     fetchMyCourses,
     myCourses,
   } = useContext(EscolaLMSContext);
+  const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [enrolling, setEnrolling] = useState(false);
   const [enrollError, setEnrollError] = useState("");
@@ -107,11 +109,14 @@ export default function CoursePage() {
       if (res.success || msg.toLowerCase().includes("already")) {
         await fetchMyCourses();
         await fetchCourseProgress(courseId);
+        toast("You're enrolled! Start learning below.");
       } else {
         setEnrollError("Enrollment failed. Please try again.");
+        toast("Enrollment failed. Please try again.", "error");
       }
     } catch {
       setEnrollError("Enrollment failed. Please try again.");
+      toast("Enrollment failed. Please try again.", "error");
     } finally {
       setEnrolling(false);
     }

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
@@ -23,6 +23,8 @@ export default function TopicPage() {
   const currentTopicId = Number(topicId);
   const router = useRouter();
   const [loading, setLoading] = useState(true);
+  const [showUserMenu, setShowUserMenu] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
 
   const ctx = useContext(EscolaLMSContext);
   const {
@@ -33,6 +35,7 @@ export default function TopicPage() {
     sendProgress,
     getNextPrevTopic,
     user,
+    logout,
     fetchMyCourses,
     myCourses,
   } = ctx;
@@ -86,6 +89,22 @@ export default function TopicPage() {
 
   const isFinished = isTopicFinished(currentTopicId);
   const isLocked = !isEnrolled && !topic?.preview;
+
+  // Close user menu on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
+        setShowUserMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const u = user.value;
+  const initials = u
+    ? `${u.first_name?.[0] ?? ""}${u.last_name?.[0] ?? ""}`.toUpperCase() || u.email[0].toUpperCase()
+    : "";
 
   // topicPing every 30s for time-on-topic analytics
   useEffect(() => {
@@ -145,18 +164,59 @@ export default function TopicPage() {
       />
 
       <div className="flex-1 flex flex-col overflow-hidden">
-        <header className="flex items-center px-6 py-3 bg-white border-b border-gray-100 shrink-0">
-          <nav className="text-sm text-gray-400">
-            <Link href="/" className="hover:text-[#1abc9c] transition-colors">
-              Courses
+        {/* Focus-mode header — minimal, no full site nav */}
+        <header className="flex items-center justify-between px-6 py-3 bg-white border-b border-gray-100 shrink-0">
+          <nav className="text-sm text-gray-400 flex items-center min-w-0">
+            <Link href={`/courses/${courseId}`} className="hover:text-[#1abc9c] transition-colors truncate max-w-[200px] sm:max-w-xs">
+              ← {course.title}
             </Link>
-            <span className="mx-2">›</span>
-            <Link href={`/courses/${courseId}`} className="hover:text-[#1abc9c] transition-colors">
-              {course.title}
-            </Link>
-            <span className="mx-2">›</span>
-            <span className="text-[#04323e]">{topic.title}</span>
+            <span className="mx-2 shrink-0">›</span>
+            <span className="text-[#04323e] truncate">{topic.title}</span>
           </nav>
+
+          {/* User menu in player header */}
+          {u && (
+            <div className="relative shrink-0 ml-4" ref={userMenuRef}>
+              <button
+                onClick={() => setShowUserMenu((v) => !v)}
+                aria-label="Open user menu"
+                className="w-8 h-8 rounded-full bg-[#1abc9c]/10 text-[#1abc9c] text-sm font-bold flex items-center justify-center hover:bg-[#1abc9c]/20 transition-colors"
+              >
+                {(u as any)?.avatar ? (
+                  <img src={(u as any).avatar} alt="" className="w-full h-full rounded-full object-cover" />
+                ) : (
+                  initials
+                )}
+              </button>
+              {showUserMenu && (
+                <div className="absolute right-0 mt-2 w-44 bg-white border border-gray-100 rounded-xl shadow-lg py-1 z-40">
+                  <div className="px-4 py-2 border-b border-gray-50">
+                    <p className="text-xs font-semibold text-[#04323e] truncate">{u.first_name || u.email}</p>
+                  </div>
+                  <Link
+                    href="/dashboard"
+                    onClick={() => setShowUserMenu(false)}
+                    className="block px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#1abc9c] transition-colors"
+                  >
+                    My courses
+                  </Link>
+                  <Link
+                    href="/profile"
+                    onClick={() => setShowUserMenu(false)}
+                    className="block px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#1abc9c] transition-colors"
+                  >
+                    Profile
+                  </Link>
+                  <button
+                    onClick={() => { logout(); setShowUserMenu(false); }}
+                    className="w-full text-left px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#04323e] transition-colors"
+                  >
+                    Sign out
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </header>
 
         <div className="flex-1 overflow-y-auto">

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { LessonNav } from "../../../../components/LessonNav";
 import { TopicContent } from "../../../../components/TopicContent";
+import { useToast } from "../../../../components/Toast";
 import type { API } from "@escolalms/sdk/lib";
 
 function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
@@ -22,6 +23,7 @@ export default function TopicPage() {
   const courseId = Number(id);
   const currentTopicId = Number(topicId);
   const router = useRouter();
+  const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
@@ -118,9 +120,13 @@ export default function TopicPage() {
     await sendProgress(courseId, [{ topic_id: currentTopicId, status: 1 }]);
     await fetchCourseProgress(courseId);
     if (nextTopic) {
+      toast("Lesson complete! Moving to next topic.");
       router.push(`/courses/${courseId}/topics/${nextTopic.id}`);
+    } else {
+      toast("Course complete! 🎉", "success");
+      router.push(`/courses/${courseId}/complete`);
     }
-  }, [courseId, currentTopicId, nextTopic, sendProgress, fetchCourseProgress, router]);
+  }, [courseId, currentTopicId, nextTopic, sendProgress, fetchCourseProgress, router, toast]);
 
   const handleVideoEnded = useCallback(() => {
     if (!isFinished) handleMarkComplete();

--- a/app/courses/layout.tsx
+++ b/app/courses/layout.tsx
@@ -1,9 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import { Nav } from "../components/Nav";
 
 export default function CoursesLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isTopicPlayer = /\/courses\/[^/]+\/topics\//.test(pathname);
+
   return (
     <>
-      <Nav />
+      {!isTopicPlayer && <Nav />}
       {children}
     </>
   );

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
+import { CourseCard } from "../components/CourseCard";
+import type { API } from "@escolalms/sdk/lib";
+
+const LEVELS = ["beginner", "intermediate", "advanced"] as const;
+
+export default function SearchPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const { courses, fetchCourses, categoryTree, fetchCategories, myCourses, fetchMyCourses, user } =
+    useContext(EscolaLMSContext);
+
+  const [mounted, setMounted] = useState(false);
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(
+    searchParams.get("category_id") ? Number(searchParams.get("category_id")) : null
+  );
+  const [activeLevel, setActiveLevel] = useState<string | null>(searchParams.get("level") ?? null);
+  const [allCourses, setAllCourses] = useState<API.CourseListItem[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const appendRef = useRef(false);
+
+  // Debounced query for API calls
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 400);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    setMounted(true);
+    fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    if (mounted && user.value) fetchMyCourses();
+  }, [mounted, user.value]);
+
+  // Sync filters → URL params (without navigation)
+  useEffect(() => {
+    if (!mounted) return;
+    const params = new URLSearchParams();
+    if (debouncedQuery) params.set("q", debouncedQuery);
+    if (activeCategoryId) params.set("category_id", String(activeCategoryId));
+    if (activeLevel) params.set("level", activeLevel);
+    const qs = params.toString();
+    router.replace(qs ? `/search?${qs}` : "/search", { scroll: false });
+  }, [debouncedQuery, activeCategoryId, activeLevel, mounted]);
+
+  // Fetch courses when filters change
+  useEffect(() => {
+    if (!mounted) return;
+    appendRef.current = false;
+    setCurrentPage(1);
+    const params: Record<string, unknown> = {};
+    if (debouncedQuery) params.title = debouncedQuery;
+    if (activeCategoryId) params.category_id = activeCategoryId;
+    if (activeLevel) params.level = activeLevel;
+    fetchCourses(params);
+  }, [debouncedQuery, activeCategoryId, activeLevel, mounted]);
+
+  // Accumulate pages
+  useEffect(() => {
+    if (!courses.list?.data) return;
+    if (appendRef.current) {
+      setAllCourses((prev) => [...prev, ...courses.list!.data]);
+    } else {
+      setAllCourses(courses.list.data);
+    }
+    appendRef.current = false;
+  }, [courses.list]);
+
+  const handleLoadMore = useCallback(() => {
+    const nextPage = currentPage + 1;
+    appendRef.current = true;
+    setCurrentPage(nextPage);
+    const params: Record<string, unknown> = { page: nextPage };
+    if (debouncedQuery) params.title = debouncedQuery;
+    if (activeCategoryId) params.category_id = activeCategoryId;
+    if (activeLevel) params.level = activeLevel;
+    fetchCourses(params);
+  }, [currentPage, debouncedQuery, activeCategoryId, activeLevel, fetchCourses]);
+
+  const meta = (courses.list as any)?.meta;
+  const hasMore = meta ? currentPage < meta.last_page : false;
+  const totalCount: number | null = meta?.total ?? null;
+
+  const categories: API.Category[] = (categoryTree as any)?.list ?? [];
+
+  const enrolledIds = useMemo(() => {
+    const val = (myCourses as any)?.value;
+    if (!val) return new Set<number>();
+    if (Array.isArray(val?.ids)) return new Set<number>(val.ids);
+    if (Array.isArray(val)) {
+      return new Set<number>(
+        val
+          .map((item: unknown) =>
+            typeof item === "number" ? item : (item as { id?: number })?.id
+          )
+          .filter((id): id is number => typeof id === "number")
+      );
+    }
+    return new Set<number>();
+  }, [myCourses]);
+
+  function clearFilters() {
+    setQuery("");
+    setActiveCategoryId(null);
+    setActiveLevel(null);
+  }
+
+  const hasFilters = !!query || activeCategoryId !== null || activeLevel !== null;
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold text-[#04323e] mb-6">Search courses</h1>
+
+      {/* Search input */}
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search by title…"
+        autoFocus
+        className="w-full border border-gray-200 rounded-full px-5 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-[#1abc9c] mb-6"
+      />
+
+      {/* Filters row */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        {/* Category filter */}
+        {categories.length > 0 && (
+          <select
+            value={activeCategoryId ?? ""}
+            onChange={(e) => setActiveCategoryId(e.target.value ? Number(e.target.value) : null)}
+            className="border border-gray-200 rounded-full px-4 py-1.5 text-sm text-[#555555] focus:outline-none focus:ring-2 focus:ring-[#1abc9c] bg-white"
+          >
+            <option value="">All categories</option>
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.name}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {/* Level filter */}
+        <select
+          value={activeLevel ?? ""}
+          onChange={(e) => setActiveLevel(e.target.value || null)}
+          className="border border-gray-200 rounded-full px-4 py-1.5 text-sm text-[#555555] focus:outline-none focus:ring-2 focus:ring-[#1abc9c] bg-white"
+        >
+          <option value="">All levels</option>
+          {LEVELS.map((level) => (
+            <option key={level} value={level}>
+              {level.charAt(0).toUpperCase() + level.slice(1)}
+            </option>
+          ))}
+        </select>
+
+        {/* Clear filters */}
+        {hasFilters && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-gray-400 hover:text-[#1abc9c] transition-colors px-2"
+          >
+            Clear filters ×
+          </button>
+        )}
+      </div>
+
+      {/* Result count */}
+      {mounted && !courses.loading && (
+        <p className="text-sm text-gray-400 mb-4">
+          {totalCount !== null
+            ? `${totalCount} course${totalCount === 1 ? "" : "s"} found`
+            : `${allCourses.length} course${allCourses.length === 1 ? "" : "s"} found`}
+        </p>
+      )}
+
+      {/* Loading state */}
+      {(!mounted || (courses.loading && allCourses.length === 0)) && (
+        <p className="text-gray-500">Loading…</p>
+      )}
+
+      {/* Empty state */}
+      {mounted && !courses.loading && allCourses.length === 0 && (
+        <div className="text-center py-16">
+          <p className="text-gray-400 text-lg mb-2">No courses match your search.</p>
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="mt-3 text-sm text-[#1abc9c] hover:underline"
+            >
+              Clear filters and try again
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Results grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {allCourses.map((course) => (
+          <CourseCard
+            key={course.id}
+            course={course}
+            isEnrolled={enrolledIds.has(course.id)}
+          />
+        ))}
+      </div>
+
+      {/* Load more */}
+      {hasMore && (
+        <div className="flex justify-center mt-10">
+          <button
+            onClick={handleLoadMore}
+            disabled={courses.loading}
+            className="px-8 py-2.5 rounded-full border border-[#1abc9c] text-[#1abc9c] font-semibold text-sm hover:bg-[#1abc9c] hover:text-white transition-colors disabled:opacity-50"
+          >
+            {courses.loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the first wave of Thrive Apprentice feature parity work tracked in issues #10–#17.

### Closes
- #13 Focus/Immersive Mode
- #15 Improved course discovery — dedicated search & filter page

### Changes

**Focus/Immersive Mode (closes #13)**
- Topic player routes (`/courses/*/topics/*`) no longer show the full site Nav
- Replaced with a minimal player header: course title breadcrumb + user avatar dropdown so students can still access their account

**Dedicated Search Page (closes #15)**
- New `/search` route with URL-param-driven filters: title, category, level
- Searches are shareable/bookmarkable — filter state lives in the URL
- Supports load-more pagination, result count, empty state, and clear-filters
- Search icon added to Nav (desktop + both logged-in/out mobile menus)

**Toast Notifications wired**
- Enrollment success/error toasts on course detail page
- "Lesson complete" toast on mark-complete in topic player
- "Course complete 🎉" toast + auto-redirect to `/complete` on final lesson

### Blocked issues (need backend verification)
- #10 Drip content — SDK has no lock/unlock date fields; backend needs verification
- #11 Lesson prerequisites — SDK has no prerequisite fields; backend needs verification
- #12 Quizzes — no quiz topic type in SDK; backend needs verification
- #14 Comments — no comments API in SDK; backend needs verification

See comments on each issue for full details.

## Test plan
- [ ] Navigate to `/courses/{id}/topics/{topicId}` — full site Nav should NOT appear; minimal header with course title and avatar dropdown should be visible
- [ ] Navigate to any other course page — full Nav should appear as normal
- [ ] Visit `/search` — filters work, URL updates, results load
- [ ] Share/reload a `/search?q=...&level=beginner` URL — filters restore correctly
- [ ] Enroll in a course — success toast appears
- [ ] Mark a lesson complete — toast appears, navigates to next topic
- [ ] Mark the final lesson complete — "Course complete" toast, redirects to certificate page