### PR TITLE
docs: add GitHub workflow conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,13 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# GitHub Workflow
+
+## Issues
+- Issues werden über die Merge-Message geschlossen: `Closes #XX` im Commit-Titel oder PR-Beschreibung — kein manuelles Schließen nötig.
+
+## Pull Requests
+- PRs immer als Draft erstellen, bis sie merge-bereit sind.
+- Vor dem Merge prüfen: keine Konflikte mit `main`, Code fehlerfrei.
+- Branch-Hierarchie beachten: einen PR der einen anderen vollständig enthält direkt mergen, den anderen schließen.


### PR DESCRIPTION
## Summary

- Documents the `Closes #XX` convention for auto-closing issues via merge messages
- Documents PR draft workflow and merge-order rules for overlapping branches

## Test plan
- [ ] Verify AGENTS.md is loaded correctly in future sessions