### PR TITLE
feat: KI/Coaching + Sprint 1 & 2 features

### DIFF
--- a/app/components/GamificationWidget.tsx
+++ b/app/components/GamificationWidget.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 
 const POINTS_KEY = "gamification_points_v1";
-const BADGES_KEY = "gamification_badges_v1";
 
 interface Badge {
   id: string;
@@ -47,6 +46,7 @@ export function awardPoints(extra = 0): { newBadges: Badge[] } {
   const updatedBadges = [...state.badges, ...newBadges.map((b) => b.id)];
   const updated: GamificationState = { points: newPoints, lessonsCompleted: newLessons, badges: updatedBadges };
   localStorage.setItem(POINTS_KEY, JSON.stringify(updated));
+  window.dispatchEvent(new Event("gamification-update"));
   return { newBadges };
 }
 
@@ -57,6 +57,9 @@ export function GamificationWidget() {
   useEffect(() => {
     setMounted(true);
     setState(loadGamification());
+    const refresh = () => setState(loadGamification());
+    window.addEventListener("gamification-update", refresh);
+    return () => window.removeEventListener("gamification-update", refresh);
   }, []);
 
   if (!mounted) return null;

--- a/app/components/GamificationWidget.tsx
+++ b/app/components/GamificationWidget.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const POINTS_KEY = "gamification_points_v1";
+const BADGES_KEY = "gamification_badges_v1";
+
+interface Badge {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  threshold: number; // lessons completed to earn
+}
+
+const BADGE_DEFINITIONS: Badge[] = [
+  { id: "first_step", name: "First Step", icon: "🌱", description: "Complete your first lesson", threshold: 1 },
+  { id: "getting_started", name: "Getting Started", icon: "🚀", description: "Complete 5 lessons", threshold: 5 },
+  { id: "committed", name: "Committed", icon: "🔥", description: "Complete 10 lessons", threshold: 10 },
+  { id: "scholar", name: "Scholar", icon: "📚", description: "Complete 25 lessons", threshold: 25 },
+  { id: "expert", name: "Expert", icon: "🏆", description: "Complete 50 lessons", threshold: 50 },
+];
+
+const POINTS_PER_LESSON = 10;
+
+export interface GamificationState {
+  points: number;
+  lessonsCompleted: number;
+  badges: string[];
+}
+
+export function loadGamification(): GamificationState {
+  try {
+    const raw = localStorage.getItem(POINTS_KEY);
+    return raw ? JSON.parse(raw) : { points: 0, lessonsCompleted: 0, badges: [] };
+  } catch { return { points: 0, lessonsCompleted: 0, badges: [] }; }
+}
+
+export function awardPoints(extra = 0): { newBadges: Badge[] } {
+  const state = loadGamification();
+  const newLessons = state.lessonsCompleted + 1;
+  const newPoints = state.points + POINTS_PER_LESSON + extra;
+  const prevBadges = new Set(state.badges);
+  const newBadges = BADGE_DEFINITIONS.filter(
+    (b) => newLessons >= b.threshold && !prevBadges.has(b.id)
+  );
+  const updatedBadges = [...state.badges, ...newBadges.map((b) => b.id)];
+  const updated: GamificationState = { points: newPoints, lessonsCompleted: newLessons, badges: updatedBadges };
+  localStorage.setItem(POINTS_KEY, JSON.stringify(updated));
+  return { newBadges };
+}
+
+export function GamificationWidget() {
+  const [state, setState] = useState<GamificationState>({ points: 0, lessonsCompleted: 0, badges: [] });
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setState(loadGamification());
+  }, []);
+
+  if (!mounted) return null;
+
+  const earnedBadges = BADGE_DEFINITIONS.filter((b) => state.badges.includes(b.id));
+  const nextBadge = BADGE_DEFINITIONS.find((b) => !state.badges.includes(b.id));
+  const progressToNext = nextBadge
+    ? Math.min(100, Math.round((state.lessonsCompleted / nextBadge.threshold) * 100))
+    : 100;
+
+  return (
+    <div className="bg-white border border-gray-100 rounded-xl p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-semibold text-[#04323e] text-sm">Your Progress</h2>
+        <span className="text-xs font-bold text-[#1abc9c]">{state.points} XP</span>
+      </div>
+
+      <p className="text-xs text-gray-400 mb-2">{state.lessonsCompleted} lessons completed</p>
+
+      {nextBadge && (
+        <>
+          <div className="w-full bg-gray-100 rounded-full h-1.5 mb-1">
+            <div
+              className="h-1.5 rounded-full bg-[#1abc9c] transition-all"
+              style={{ width: `${progressToNext}%` }}
+            />
+          </div>
+          <p className="text-xs text-gray-400 mb-3">
+            {nextBadge.icon} {state.lessonsCompleted}/{nextBadge.threshold} lessons to earn "{nextBadge.name}"
+          </p>
+        </>
+      )}
+
+      {earnedBadges.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {earnedBadges.map((b) => (
+            <span
+              key={b.id}
+              title={b.description}
+              className="text-lg cursor-default"
+            >
+              {b.icon}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/GenerateFlashcardsButton.tsx
+++ b/app/components/GenerateFlashcardsButton.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { loadCards, saveCards } from "../flashcards/page";
+import type { Flashcard } from "../flashcards/page";
+
+interface Props {
+  topicId: number;
+  topicTitle: string;
+  htmlContent: string;
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim().slice(0, 3000);
+}
+
+function newCard(topicId: number, topicTitle: string, question: string, answer: string): Flashcard {
+  return {
+    id: `${topicId}_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+    topicId,
+    topicTitle,
+    question,
+    answer,
+    easeFactor: 2.5,
+    interval: 0,
+    repetitions: 0,
+    nextReview: new Date().toISOString().split("T")[0],
+  };
+}
+
+export function GenerateFlashcardsButton({ topicId, topicTitle, htmlContent }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const [count, setCount] = useState(0);
+  const [error, setError] = useState("");
+
+  const handleGenerate = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const text = stripHtml(htmlContent);
+      if (text.length < 30) { setError("Zu wenig Inhalt zum Generieren."); setLoading(false); return; }
+
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          systemPrompt:
+            'Du bist ein Lernkarten-Generator. Erstelle 5–8 Flashcards aus dem Lerninhalt. Antworte NUR mit einem JSON-Array, keine Erklärungen davor oder danach. Format: [{"q":"Frage","a":"Antwort"},...]',
+          messages: [
+            {
+              role: "user",
+              content: `Thema: "${topicTitle}"\n\n${text}`,
+            },
+          ],
+        }),
+      });
+      const data = await res.json();
+      if (!data.content) throw new Error("Keine Antwort");
+
+      const jsonMatch = data.content.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) throw new Error("Ungültiges Format");
+      const pairs: { q: string; a: string }[] = JSON.parse(jsonMatch[0]);
+
+      const existing = loadCards();
+      const newCards = pairs
+        .filter((p) => p.q && p.a)
+        .map((p) => newCard(topicId, topicTitle, p.q, p.a));
+      saveCards([...existing, ...newCards]);
+      setCount(newCards.length);
+      setDone(true);
+    } catch {
+      setError("Flashcards konnten nicht generiert werden.");
+    }
+    setLoading(false);
+  }, [topicId, topicTitle, htmlContent]);
+
+  if (done) {
+    return (
+      <p className="text-sm text-[#1abc9c]">
+        {count} Flashcards erstellt!{" "}
+        <Link href="/flashcards" className="underline hover:no-underline">
+          Jetzt lernen →
+        </Link>
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={handleGenerate}
+        disabled={loading}
+        className="inline-flex items-center gap-2 text-sm font-medium text-[#555555] border border-gray-200 hover:border-[#1abc9c] hover:text-[#1abc9c] px-4 py-2 rounded-full transition-colors disabled:opacity-50"
+      >
+        {loading ? (
+          <>
+            <span className="animate-spin">⟳</span> Generiere Flashcards…
+          </>
+        ) : (
+          <>🃏 Flashcards generieren</>
+        )}
+      </button>
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/app/components/GiftQuizPlayer.tsx
+++ b/app/components/GiftQuizPlayer.tsx
@@ -318,12 +318,11 @@ export function GiftQuizPlayer({ topic, onComplete, onPass }: Props) {
       const maxScore = finished?.max_score ?? attempt.max_score ?? 0;
       setScore({ result: resultScore, max: maxScore });
       setFinished(true);
+      const pct = maxScore > 0 ? Math.round((resultScore / maxScore) * 100) : 0;
       if (onComplete) onComplete();
-      const pctNow = maxScore > 0 ? Math.round((resultScore / maxScore) * 100) : 0;
-      if (pctNow >= 60 && onPass) onPass();
+      if (pct >= 60 && onPass) onPass();
 
       // Fetch AI gap analysis for incomplete scores
-      const pct = maxScore > 0 ? Math.round((resultScore / maxScore) * 100) : 0;
       if (pct < 100 && questions.length > 0) {
         setGapLoading(true);
         const questionSummary = questions

--- a/app/components/GiftQuizPlayer.tsx
+++ b/app/components/GiftQuizPlayer.tsx
@@ -13,6 +13,7 @@ type AnswerMap = Record<number, string | string[]>;
 interface Props {
   topic: API.TopicQuiz;
   onComplete?: () => void;
+  onPass?: () => void;
 }
 
 // ─── Individual question renderers ──────────────────────────────────────────
@@ -231,7 +232,7 @@ function QuestionCard({
 
 // ─── Main quiz player ─────────────────────────────────────────────────────────
 
-export function GiftQuizPlayer({ topic, onComplete }: Props) {
+export function GiftQuizPlayer({ topic, onComplete, onPass }: Props) {
   const ctx = useContext(EscolaLMSContext) as any;
   const { user, apiUrl, token } = ctx;
 
@@ -318,6 +319,8 @@ export function GiftQuizPlayer({ topic, onComplete }: Props) {
       setScore({ result: resultScore, max: maxScore });
       setFinished(true);
       if (onComplete) onComplete();
+      const pctNow = maxScore > 0 ? Math.round((resultScore / maxScore) * 100) : 0;
+      if (pctNow >= 60 && onPass) onPass();
 
       // Fetch AI gap analysis for incomplete scores
       const pct = maxScore > 0 ? Math.round((resultScore / maxScore) * 100) : 0;

--- a/app/components/LearningGoalWidget.tsx
+++ b/app/components/LearningGoalWidget.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const GOAL_KEY = "lernziel_goal";
+const WEEK_KEY = "lernziel_week";
+const COUNT_KEY = "lernziel_count";
+
+function isoWeek(date: Date): string {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const year = d.getUTCFullYear();
+  const week = Math.ceil(((d.getTime() - Date.UTC(year, 0, 1)) / 86400000 + 1) / 7);
+  return `${year}-W${String(week).padStart(2, "0")}`;
+}
+
+export function recordLessonCompletion() {
+  if (typeof window === "undefined") return;
+  const week = isoWeek(new Date());
+  const stored = localStorage.getItem(WEEK_KEY);
+  const count = stored === week ? Number(localStorage.getItem(COUNT_KEY) ?? 0) : 0;
+  localStorage.setItem(WEEK_KEY, week);
+  localStorage.setItem(COUNT_KEY, String(count + 1));
+}
+
+export function LearningGoalWidget() {
+  const [goal, setGoal] = useState(5);
+  const [count, setCount] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("5");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const storedGoal = Number(localStorage.getItem(GOAL_KEY) ?? 5);
+    setGoal(storedGoal);
+    setDraft(String(storedGoal));
+
+    const week = isoWeek(new Date());
+    const storedWeek = localStorage.getItem(WEEK_KEY);
+    const storedCount = storedWeek === week ? Number(localStorage.getItem(COUNT_KEY) ?? 0) : 0;
+    setCount(storedCount);
+  }, []);
+
+  if (!mounted) return null;
+
+  const pct = Math.min(100, Math.round((count / goal) * 100));
+  const done = count >= goal;
+
+  function saveGoal() {
+    const n = Math.max(1, Math.min(99, Number(draft) || goal));
+    setGoal(n);
+    setDraft(String(n));
+    localStorage.setItem(GOAL_KEY, String(n));
+    setEditing(false);
+  }
+
+  return (
+    <div className="bg-white border border-gray-100 rounded-xl p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-semibold text-[#04323e] text-sm">Wochenziel</h2>
+        {!editing && (
+          <button
+            onClick={() => setEditing(true)}
+            className="text-xs text-gray-400 hover:text-[#1abc9c] transition-colors"
+          >
+            Anpassen
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="flex items-center gap-2 mb-3">
+          <input
+            type="number"
+            min={1}
+            max={99}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && saveGoal()}
+            className="w-16 border border-gray-200 rounded-lg px-2 py-1 text-sm text-center focus:outline-none focus:border-[#1abc9c]"
+            autoFocus
+          />
+          <span className="text-sm text-gray-500">Lektionen / Woche</span>
+          <button
+            onClick={saveGoal}
+            className="ml-auto text-xs bg-[#1abc9c] text-white px-3 py-1 rounded-full hover:bg-[#15a288] transition-colors"
+          >
+            Speichern
+          </button>
+        </div>
+      ) : (
+        <p className="text-xs text-gray-400 mb-3">
+          {done ? "Ziel erreicht! 🎉" : `${count} von ${goal} Lektionen diese Woche`}
+        </p>
+      )}
+
+      <div className="w-full bg-gray-100 rounded-full h-2 mb-1">
+        <div
+          className={`h-2 rounded-full transition-all ${done ? "bg-[#1abc9c]" : "bg-[#1abc9c]/60"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-gray-400 text-right">{pct}%</p>
+    </div>
+  );
+}

--- a/app/components/LearningNudge.tsx
+++ b/app/components/LearningNudge.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useToast } from "./Toast";
+
+const LAST_ACTIVITY_KEY = "nudge_last_activity";
+const NUDGE_SHOWN_KEY = "nudge_last_shown";
+// Show a nudge if idle for more than 24h and haven't been nudged in 4h
+const IDLE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const NUDGE_COOLDOWN_MS = 4 * 60 * 60 * 1000;
+
+export function recordLearningActivity() {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(LAST_ACTIVITY_KEY, Date.now().toString());
+  }
+}
+
+const NUDGES = [
+  "Du hast länger nicht gelernt — wie wäre es mit einer kurzen Lektion?",
+  "Regelmäßiges Lernen macht den Unterschied. Bereit für heute?",
+  "Deine Flashcards warten auf dich! Zeit für eine kurze Wiederholung.",
+  "Kleine Lerneinheiten jeden Tag führen zu großen Ergebnissen.",
+];
+
+export function LearningNudge() {
+  const { toast } = useToast();
+  const shown = useRef(false);
+
+  const check = useCallback(() => {
+    if (shown.current) return;
+    const lastActivity = Number(localStorage.getItem(LAST_ACTIVITY_KEY) ?? 0);
+    const lastNudge = Number(localStorage.getItem(NUDGE_SHOWN_KEY) ?? 0);
+    const now = Date.now();
+    const idle = lastActivity > 0 && now - lastActivity > IDLE_THRESHOLD_MS;
+    const cooldownOk = now - lastNudge > NUDGE_COOLDOWN_MS;
+    if (idle && cooldownOk) {
+      const msg = NUDGES[Math.floor(Math.random() * NUDGES.length)];
+      toast(msg);
+      localStorage.setItem(NUDGE_SHOWN_KEY, now.toString());
+      shown.current = true;
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    const t = setTimeout(check, 3000);
+    return () => clearTimeout(t);
+  }, [check]);
+
+  return null;
+}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -52,6 +52,16 @@ export function Nav() {
     ? `${u.first_name?.[0] ?? ""}${u.last_name?.[0] ?? ""}`.toUpperCase() || u.email[0].toUpperCase()
     : "";
 
+  const isTutor = useMemo(() => {
+    const roles: unknown = (u as any)?.roles;
+    if (!Array.isArray(roles)) return false;
+    return roles.some((r: any) =>
+      typeof r === "string"
+        ? r === "author" || r === "tutor"
+        : r?.name === "author" || r?.name === "tutor"
+    );
+  }, [u]);
+
   return (
     <>
       <nav className="border-b bg-white px-4 py-3 flex items-center justify-between relative z-30">
@@ -149,6 +159,15 @@ export function Nav() {
                     >
                       Profile
                     </Link>
+                    {isTutor && (
+                      <Link
+                        href="/tutor"
+                        onClick={() => setShowDropdown(false)}
+                        className="block px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#1abc9c] transition-colors"
+                      >
+                        Tutor area
+                      </Link>
+                    )}
                     <button
                       onClick={() => { logout(); setShowDropdown(false); }}
                       className="w-full text-left px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#04323e] transition-colors"
@@ -224,6 +243,11 @@ export function Nav() {
               <Link href="/profile" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
                 Profile
               </Link>
+              {isTutor && (
+                <Link href="/tutor" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
+                  Tutor area
+                </Link>
+              )}
               <button
                 onClick={() => { logout(); setShowMobileMenu(false); }}
                 className="text-left text-sm font-medium text-[#555555] hover:text-[#04323e] transition-colors py-1"

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { LoginForm } from "./LoginForm";
 import { CartDrawer } from "./CartDrawer";
+import { NotificationBell } from "./NotificationBell";
 import type { API } from "@escolalms/sdk/lib";
 
 export function Nav() {
@@ -102,6 +103,7 @@ export function Nav() {
 
           {loggedIn ? (
             <>
+              <NotificationBell />
               <Link
                 href="/dashboard"
                 className={`text-sm font-medium transition-colors ${

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -153,6 +153,13 @@ export function Nav() {
                       Bookmarks
                     </Link>
                     <Link
+                      href="/flashcards"
+                      onClick={() => setShowDropdown(false)}
+                      className="block px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#1abc9c] transition-colors"
+                    >
+                      Flashcards
+                    </Link>
+                    <Link
                       href="/profile"
                       onClick={() => setShowDropdown(false)}
                       className="block px-4 py-2 text-sm text-[#555555] hover:bg-gray-50 hover:text-[#1abc9c] transition-colors"
@@ -242,6 +249,9 @@ export function Nav() {
               </Link>
               <Link href="/profile" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
                 Profile
+              </Link>
+              <Link href="/flashcards" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">
+                Flashcards
               </Link>
               {isTutor && (
                 <Link href="/tutor" className="text-sm font-medium text-[#555555] hover:text-[#1abc9c] transition-colors py-1">

--- a/app/components/NotificationBell.tsx
+++ b/app/components/NotificationBell.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
-import type { API } from "@escolalms/sdk/lib";
 
 type SDKNotification = {
   id: string;
@@ -36,7 +35,7 @@ export function NotificationBell() {
     fetchNotifications();
     const iv = setInterval(fetchNotifications, 60_000);
     return () => clearInterval(iv);
-  }, [user?.value]);
+  }, [user?.value, fetchNotifications]);
 
   useEffect(() => {
     function onClick(e: MouseEvent) {
@@ -59,7 +58,7 @@ export function NotificationBell() {
     <div className="relative" ref={ref}>
       <button
         onClick={() => setOpen((v) => !v)}
-        aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ""}`}
+        aria-label={`Benachrichtigungen${unread > 0 ? `, ${unread} ungelesen` : ""}`}
         className="relative text-[#555555] hover:text-[#1abc9c] transition-colors"
       >
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -76,20 +75,20 @@ export function NotificationBell() {
       {open && (
         <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-100 rounded-xl shadow-lg z-40 overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-50">
-            <p className="text-sm font-semibold text-[#04323e]">Notifications</p>
+            <p className="text-sm font-semibold text-[#04323e]">Benachrichtigungen</p>
             {unread > 0 && (
               <button
                 onClick={() => readAllNotifications()}
                 className="text-xs text-[#1abc9c] hover:underline"
               >
-                Mark all read
+                Alle als gelesen markieren
               </button>
             )}
           </div>
 
           <ul className="max-h-80 overflow-y-auto divide-y divide-gray-50">
             {items.length === 0 && (
-              <li className="px-4 py-6 text-sm text-gray-400 text-center">No notifications</li>
+              <li className="px-4 py-6 text-sm text-gray-400 text-center">Keine Benachrichtigungen</li>
             )}
             {items.slice(0, 20).map((n) => (
               <li

--- a/app/components/NotificationBell.tsx
+++ b/app/components/NotificationBell.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
+import type { API } from "@escolalms/sdk/lib";
+
+type SDKNotification = {
+  id: string;
+  read_at: null | Date | string;
+  created_at: Date | string;
+  event: string;
+  data: {
+    course?: { title?: string };
+    order?: { id?: number };
+    notification?: { sections?: { key: string; value: string }[] };
+  };
+};
+
+function notificationLabel(n: SDKNotification): string {
+  if (n.data?.course?.title) return `Course update: ${n.data.course.title}`;
+  if (n.data?.order?.id) return `Order #${n.data.order.id} update`;
+  const msg = n.data?.notification?.sections?.find((s) => s.key === "message")?.value;
+  if (msg) return msg;
+  return n.event?.split("\\").pop() ?? "New notification";
+}
+
+export function NotificationBell() {
+  const ctx = useContext(EscolaLMSContext) as any;
+  const { user, fetchNotifications, readNotify, readAllNotifications, notifications } = ctx;
+
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!user?.value) return;
+    fetchNotifications();
+    const iv = setInterval(fetchNotifications, 60_000);
+    return () => clearInterval(iv);
+  }, [user?.value]);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  const items: SDKNotification[] = useMemo(() => {
+    const raw = notifications?.value?.data ?? notifications?.value ?? [];
+    return Array.isArray(raw) ? raw : [];
+  }, [notifications]);
+
+  const unread = items.filter((n) => !n.read_at).length;
+
+  if (!user?.value) return null;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ""}`}
+        className="relative text-[#555555] hover:text-[#1abc9c] transition-colors"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        {unread > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center">
+            {unread > 9 ? "9+" : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-100 rounded-xl shadow-lg z-40 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-50">
+            <p className="text-sm font-semibold text-[#04323e]">Notifications</p>
+            {unread > 0 && (
+              <button
+                onClick={() => readAllNotifications()}
+                className="text-xs text-[#1abc9c] hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <ul className="max-h-80 overflow-y-auto divide-y divide-gray-50">
+            {items.length === 0 && (
+              <li className="px-4 py-6 text-sm text-gray-400 text-center">No notifications</li>
+            )}
+            {items.slice(0, 20).map((n) => (
+              <li
+                key={n.id}
+                onClick={() => { if (!n.read_at) readNotify(n.id); }}
+                className={`px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors ${!n.read_at ? "bg-[#1abc9c]/5" : ""}`}
+              >
+                <p className="text-sm text-[#04323e] leading-snug">{notificationLabel(n)}</p>
+                <p className="text-xs text-gray-400 mt-0.5">
+                  {new Date(n.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/ProjectUpload.tsx
+++ b/app/components/ProjectUpload.tsx
@@ -6,9 +6,10 @@ import type { API } from "@escolalms/sdk/lib";
 
 interface Props {
   topicId: number;
+  topicTitle?: string;
 }
 
-export function ProjectUpload({ topicId }: Props) {
+export function ProjectUpload({ topicId, topicTitle }: Props) {
   const { user, apiUrl, token } = useContext(EscolaLMSContext) as any;
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -16,6 +17,8 @@ export function ProjectUpload({ topicId }: Props) {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [aiFeedback, setAiFeedback] = useState<string | null>(null);
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
 
   const loadSubmissions = useCallback(async () => {
     if (!token) return;
@@ -54,6 +57,28 @@ export function ProjectUpload({ topicId }: Props) {
         setSuccess("Assignment submitted successfully!");
         if (fileRef.current) fileRef.current.value = "";
         await loadSubmissions();
+        if (topicTitle) {
+          setFeedbackLoading(true);
+          try {
+            const fbRes = await fetch("/api/chat", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                systemPrompt:
+                  "Du bist ein hilfreicher Tutor. Gib konstruktives erstes Feedback zu einer Projektabgabe. Sei ermutigend und konkret. Antworte auf Deutsch in 3-4 Sätzen.",
+                messages: [
+                  {
+                    role: "user",
+                    content: `Der Student hat eine Projektabgabe eingereicht für: "${topicTitle}". Gib allgemeines konstruktives Feedback.`,
+                  },
+                ],
+              }),
+            });
+            const fbData = await fbRes.json();
+            if (fbData.content) setAiFeedback(fbData.content);
+          } catch {}
+          setFeedbackLoading(false);
+        }
       } else {
         const json = await res.json().catch(() => ({}));
         setError(json?.message ?? "Upload failed. Please try again.");
@@ -63,7 +88,7 @@ export function ProjectUpload({ topicId }: Props) {
     } finally {
       setUploading(false);
     }
-  }, [apiUrl, token, topicId, loadSubmissions]);
+  }, [apiUrl, token, topicId, topicTitle, loadSubmissions]);
 
   if (!user.value) {
     return <p className="text-gray-400 text-sm">Sign in to submit your assignment.</p>;
@@ -80,7 +105,7 @@ export function ProjectUpload({ topicId }: Props) {
           type="file"
           id="project-upload"
           className="hidden"
-          onChange={() => setSuccess("")}
+          onChange={() => { setSuccess(""); setAiFeedback(null); }}
         />
         <label
           htmlFor="project-upload"
@@ -100,6 +125,16 @@ export function ProjectUpload({ topicId }: Props) {
 
       {success && <p className="text-sm text-[#1abc9c] font-medium">{success}</p>}
       {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {feedbackLoading && (
+        <p className="text-sm text-amber-600 animate-pulse">KI analysiert deine Abgabe…</p>
+      )}
+      {aiFeedback && !feedbackLoading && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 leading-relaxed">
+          <p className="font-semibold mb-1">KI-Feedback</p>
+          <p className="whitespace-pre-line">{aiFeedback}</p>
+        </div>
+      )}
 
       {submissions.length > 0 && (
         <div className="mt-4">

--- a/app/components/RecommendedCourses.tsx
+++ b/app/components/RecommendedCourses.tsx
@@ -63,7 +63,7 @@ export function RecommendedCourses({ enrolledTitles, allCourses, enrolledIds }: 
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, []);
+  }, [enrolledTitles.join(","), allCourses.length]);
 
   if (loading) {
     return (

--- a/app/components/RecommendedCourses.tsx
+++ b/app/components/RecommendedCourses.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { API } from "@escolalms/sdk/lib";
+
+interface Props {
+  enrolledTitles: string[];
+  allCourses: API.CourseListItem[];
+  enrolledIds: Set<number>;
+}
+
+const CACHE_KEY = "ai_recommendations_v1";
+
+export function RecommendedCourses({ enrolledTitles, allCourses, enrolledIds }: Props) {
+  const [recommended, setRecommended] = useState<API.CourseListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const unenrolled = allCourses.filter((c) => !enrolledIds.has(c.id));
+    if (!enrolledTitles.length || unenrolled.length === 0) return;
+
+    const cacheRaw = sessionStorage.getItem(CACHE_KEY);
+    if (cacheRaw) {
+      try {
+        const ids: number[] = JSON.parse(cacheRaw);
+        const picked = ids.map((id) => unenrolled.find((c) => c.id === id)).filter(Boolean) as API.CourseListItem[];
+        if (picked.length) { setRecommended(picked); return; }
+      } catch {}
+    }
+
+    setLoading(true);
+    const catalog = unenrolled.slice(0, 30).map((c) => `${c.id}: ${c.title}`).join("\n");
+    fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemPrompt:
+          "Du bist ein Kursempfehlungssystem. Basierend auf den belegten Kursen eines Nutzers, wähle genau 3 passende Kurse aus dem Katalog aus. Antworte NUR mit einer kommaseparierten Liste der Kurs-IDs, zum Beispiel: 12,7,34",
+        messages: [
+          {
+            role: "user",
+            content: `Belegte Kurse:\n${enrolledTitles.join("\n")}\n\nVerfügbarer Katalog:\n${catalog}\n\nGib 3 Kurs-IDs zurück.`,
+          },
+        ],
+      }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!data.content) return;
+        const ids = (data.content as string)
+          .split(/[,\s]+/)
+          .map(Number)
+          .filter((n) => !isNaN(n) && n > 0);
+        const picked = ids
+          .map((id) => unenrolled.find((c) => c.id === id))
+          .filter(Boolean)
+          .slice(0, 3) as API.CourseListItem[];
+        if (picked.length) {
+          sessionStorage.setItem(CACHE_KEY, JSON.stringify(picked.map((c) => c.id)));
+          setRecommended(picked);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold text-[#04323e] mb-3">Empfohlen für dich</h2>
+        <p className="text-sm text-gray-400 animate-pulse">KI analysiert deine Lernpräferenzen…</p>
+      </div>
+    );
+  }
+
+  if (!recommended.length) return null;
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold text-[#04323e] mb-3">Empfohlen für dich ✨</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {recommended.map((course) => (
+          <Link
+            key={course.id}
+            href={`/courses/${course.id}`}
+            className="block bg-white border border-gray-100 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+          >
+            {course.image_url ? (
+              <img src={course.image_url} alt={course.title} className="w-full h-28 object-cover" />
+            ) : (
+              <div className="w-full h-28 bg-gray-50" />
+            )}
+            <div className="px-4 py-3">
+              <p className="text-sm font-semibold text-[#04323e] line-clamp-2">{course.title}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/TopicContent.tsx
+++ b/app/components/TopicContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import type { API } from "@escolalms/sdk/lib";
 import { TopicType } from "@escolalms/sdk/lib/types/enums";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
@@ -50,6 +50,32 @@ function H5PPlayer({ topic }: { topic: API.TopicH5P }) {
   );
 }
 
+function VideoPlayer({ src, poster, onEnded, onWatchedEnough }: {
+  src: string;
+  poster?: string;
+  onEnded?: () => void;
+  onWatchedEnough?: () => void;
+}) {
+  const watchedFired = useRef(false);
+  return (
+    <video
+      src={src}
+      poster={poster}
+      controls
+      onEnded={onEnded}
+      onTimeUpdate={(e) => {
+        if (watchedFired.current || !onWatchedEnough) return;
+        const v = e.currentTarget;
+        if (v.duration > 0 && v.currentTime / v.duration >= 0.9) {
+          watchedFired.current = true;
+          onWatchedEnough();
+        }
+      }}
+      className="w-full rounded-lg aspect-video bg-black"
+    />
+  );
+}
+
 export function TopicContent({ topic, onVideoEnded, onComplete, onWatchedEnough, onPass }: TopicContentProps) {
   if (!topic.topicable_type) {
     return <p className="text-gray-500">No content available.</p>;
@@ -67,24 +93,7 @@ export function TopicContent({ topic, onVideoEnded, onComplete, onWatchedEnough,
 
     case TopicType.Video: {
       const t = topic as API.TopicVideo;
-      let watchedFired = false;
-      return (
-        <video
-          src={t.topicable.url}
-          poster={t.topicable.poster_url}
-          controls
-          onEnded={onVideoEnded}
-          onTimeUpdate={(e) => {
-            if (watchedFired || !onWatchedEnough) return;
-            const v = e.currentTarget;
-            if (v.duration > 0 && v.currentTime / v.duration >= 0.9) {
-              watchedFired = true;
-              onWatchedEnough();
-            }
-          }}
-          className="w-full rounded-lg aspect-video bg-black"
-        />
-      );
+      return <VideoPlayer src={t.topicable.url} poster={t.topicable.poster_url} onEnded={onVideoEnded} onWatchedEnough={onWatchedEnough} />;
     }
 
     case TopicType.OEmbed: {

--- a/app/components/TopicContent.tsx
+++ b/app/components/TopicContent.tsx
@@ -12,6 +12,8 @@ interface TopicContentProps {
   topic: API.Topic;
   onVideoEnded?: () => void;
   onComplete?: () => void;
+  onWatchedEnough?: () => void;
+  onPass?: () => void;
 }
 
 function H5PPlayer({ topic }: { topic: API.TopicH5P }) {
@@ -48,7 +50,7 @@ function H5PPlayer({ topic }: { topic: API.TopicH5P }) {
   );
 }
 
-export function TopicContent({ topic, onVideoEnded, onComplete }: TopicContentProps) {
+export function TopicContent({ topic, onVideoEnded, onComplete, onWatchedEnough, onPass }: TopicContentProps) {
   if (!topic.topicable_type) {
     return <p className="text-gray-500">No content available.</p>;
   }
@@ -65,12 +67,21 @@ export function TopicContent({ topic, onVideoEnded, onComplete }: TopicContentPr
 
     case TopicType.Video: {
       const t = topic as API.TopicVideo;
+      let watchedFired = false;
       return (
         <video
           src={t.topicable.url}
           poster={t.topicable.poster_url}
           controls
           onEnded={onVideoEnded}
+          onTimeUpdate={(e) => {
+            if (watchedFired || !onWatchedEnough) return;
+            const v = e.currentTarget;
+            if (v.duration > 0 && v.currentTime / v.duration >= 0.9) {
+              watchedFired = true;
+              onWatchedEnough();
+            }
+          }}
           className="w-full rounded-lg aspect-video bg-black"
         />
       );
@@ -124,7 +135,7 @@ export function TopicContent({ topic, onVideoEnded, onComplete }: TopicContentPr
       return <ProjectUpload topicId={topic.id} topicTitle={topic.title} />;
 
     case TopicType.GiftQuiz:
-      return <GiftQuizPlayer topic={topic as API.TopicQuiz} onComplete={onVideoEnded} />;
+      return <GiftQuizPlayer topic={topic as API.TopicQuiz} onComplete={onVideoEnded} onPass={onPass} />;
 
     default: {
       const unknown = topic as API.Topic;

--- a/app/components/TopicContent.tsx
+++ b/app/components/TopicContent.tsx
@@ -121,7 +121,7 @@ export function TopicContent({ topic, onVideoEnded, onComplete }: TopicContentPr
     }
 
     case TopicType.Project:
-      return <ProjectUpload topicId={topic.id} />;
+      return <ProjectUpload topicId={topic.id} topicTitle={topic.title} />;
 
     case TopicType.GiftQuiz:
       return <GiftQuizPlayer topic={topic as API.TopicQuiz} onComplete={onVideoEnded} />;

--- a/app/components/TopicQA.tsx
+++ b/app/components/TopicQA.tsx
@@ -21,6 +21,7 @@ export function TopicQA({ topicId, topicTitle }: Props) {
   const [entries, setEntries] = useState<QAEntry[]>([]);
   const [question, setQuestion] = useState("");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -35,6 +36,7 @@ export function TopicQA({ topicId, topicTitle }: Props) {
     const q = question.trim();
     if (!q || loading) return;
     setLoading(true);
+    setError(false);
     try {
       const res = await fetch("/api/chat", {
         method: "POST",
@@ -52,7 +54,9 @@ export function TopicQA({ topicId, topicTitle }: Props) {
         localStorage.setItem(storageKey(topicId), JSON.stringify(next));
         setQuestion("");
       }
-    } catch {}
+    } catch {
+      setError(true);
+    }
     setLoading(false);
   }
 
@@ -87,6 +91,9 @@ export function TopicQA({ topicId, topicTitle }: Props) {
             >
               {loading ? "KI antwortet…" : "Fragen"}
             </button>
+            {error && (
+              <p className="text-xs text-red-500">Antwort konnte nicht geladen werden. Bitte erneut versuchen.</p>
+            )}
           </div>
 
           {entries.length > 0 && (

--- a/app/components/TopicQA.tsx
+++ b/app/components/TopicQA.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface QAEntry {
+  question: string;
+  answer: string;
+  ts: number;
+}
+
+interface Props {
+  topicId: number;
+  topicTitle: string;
+}
+
+function storageKey(topicId: number) {
+  return `topic_qa_${topicId}`;
+}
+
+export function TopicQA({ topicId, topicTitle }: Props) {
+  const [entries, setEntries] = useState<QAEntry[]>([]);
+  const [question, setQuestion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(storageKey(topicId));
+      if (raw) setEntries(JSON.parse(raw));
+    } catch {}
+  }, [topicId]);
+
+  async function handleAsk() {
+    const q = question.trim();
+    if (!q || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          systemPrompt: `Du bist ein hilfreicher Lernassistent für den Kurs-Inhalt "${topicTitle}". Beantworte Lernerfragen klar und präzise auf Deutsch. Wenn du die Antwort nicht weißt, sag es ehrlich.`,
+          messages: [{ role: "user", content: q }],
+        }),
+      });
+      const data = await res.json();
+      if (data.content) {
+        const entry: QAEntry = { question: q, answer: data.content, ts: Date.now() };
+        const next = [entry, ...entries].slice(0, 20);
+        setEntries(next);
+        localStorage.setItem(storageKey(topicId), JSON.stringify(next));
+        setQuestion("");
+      }
+    } catch {}
+    setLoading(false);
+  }
+
+  return (
+    <div className="mt-8 border-t border-gray-100 pt-6">
+      <button
+        onClick={() => { setOpen((v) => !v); if (!open) setTimeout(() => inputRef.current?.focus(), 50); }}
+        className="flex items-center gap-2 text-sm font-semibold text-[#04323e] hover:text-[#1abc9c] transition-colors"
+      >
+        <span>{open ? "▾" : "▸"}</span>
+        Fragen & Antworten {entries.length > 0 && `(${entries.length})`}
+      </button>
+
+      {open && (
+        <div className="mt-4 space-y-4">
+          <div className="flex flex-col gap-2">
+            <textarea
+              ref={inputRef}
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleAsk();
+              }}
+              placeholder="Stelle eine Frage zu diesem Thema… (Strg+Enter zum Senden)"
+              rows={3}
+              className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-[#1abc9c] resize-none"
+            />
+            <button
+              onClick={handleAsk}
+              disabled={loading || !question.trim()}
+              className="self-end bg-[#1abc9c] hover:bg-[#15a288] disabled:opacity-50 text-white text-sm font-semibold px-5 py-2 rounded-full transition-colors"
+            >
+              {loading ? "KI antwortet…" : "Fragen"}
+            </button>
+          </div>
+
+          {entries.length > 0 && (
+            <ul className="space-y-4">
+              {entries.map((e) => (
+                <li key={e.ts} className="rounded-xl border border-gray-100 bg-gray-50 p-4 space-y-2">
+                  <p className="text-sm font-semibold text-[#04323e]">F: {e.question}</p>
+                  <p className="text-sm text-[#555555] whitespace-pre-line leading-relaxed">A: {e.answer}</p>
+                  <p className="text-xs text-gray-300">{new Date(e.ts).toLocaleString("de-DE")}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -13,6 +13,7 @@ import { AiChatWidget } from "../../../../components/AiChatWidget";
 import { useToast } from "../../../../components/Toast";
 import { recordLessonCompletion } from "../../../../components/LearningGoalWidget";
 import { TopicQA } from "../../../../components/TopicQA";
+import { GenerateFlashcardsButton } from "../../../../components/GenerateFlashcardsButton";
 import type { API } from "@escolalms/sdk/lib";
 
 function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
@@ -312,6 +313,16 @@ export default function TopicPage() {
                     </li>
                   ))}
                 </ul>
+              </div>
+            )}
+
+            {!isLocked && topic.topicable_type === TopicType.RichText && (
+              <div className="mt-6">
+                <GenerateFlashcardsButton
+                  topicId={currentTopicId}
+                  topicTitle={topic.title}
+                  htmlContent={(topic as API.TopicRichText).topicable?.value ?? ""}
+                />
               </div>
             )}
 

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -13,6 +13,7 @@ import { AiChatWidget } from "../../../../components/AiChatWidget";
 import { useToast } from "../../../../components/Toast";
 import { recordLessonCompletion } from "../../../../components/LearningGoalWidget";
 import { recordLearningActivity } from "../../../../components/LearningNudge";
+import { awardPoints } from "../../../../components/GamificationWidget";
 import { TopicQA } from "../../../../components/TopicQA";
 import { GenerateFlashcardsButton } from "../../../../components/GenerateFlashcardsButton";
 import type { API } from "@escolalms/sdk/lib";
@@ -153,6 +154,7 @@ export default function TopicPage() {
     await fetchCourseProgress(courseId);
     recordLessonCompletion();
     recordLearningActivity();
+    awardPoints();
 
     const nextPath = nextTopic
       ? `/courses/${courseId}/topics/${nextTopic.id}`

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -12,6 +12,7 @@ import { ExplainDifferentlyButton } from "../../../../components/ExplainDifferen
 import { AiChatWidget } from "../../../../components/AiChatWidget";
 import { useToast } from "../../../../components/Toast";
 import { recordLessonCompletion } from "../../../../components/LearningGoalWidget";
+import { recordLearningActivity } from "../../../../components/LearningNudge";
 import { TopicQA } from "../../../../components/TopicQA";
 import { GenerateFlashcardsButton } from "../../../../components/GenerateFlashcardsButton";
 import type { API } from "@escolalms/sdk/lib";
@@ -129,6 +130,7 @@ export default function TopicPage() {
     await sendProgress(courseId, [{ topic_id: currentTopicId, status: 1 }]);
     await fetchCourseProgress(courseId);
     recordLessonCompletion();
+    recordLearningActivity();
 
     const nextPath = nextTopic
       ? `/courses/${courseId}/topics/${nextTopic.id}`

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -12,6 +12,7 @@ import { ExplainDifferentlyButton } from "../../../../components/ExplainDifferen
 import { AiChatWidget } from "../../../../components/AiChatWidget";
 import { useToast } from "../../../../components/Toast";
 import { recordLessonCompletion } from "../../../../components/LearningGoalWidget";
+import { TopicQA } from "../../../../components/TopicQA";
 import type { API } from "@escolalms/sdk/lib";
 
 function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
@@ -312,6 +313,10 @@ export default function TopicPage() {
                   ))}
                 </ul>
               </div>
+            )}
+
+            {!isLocked && (
+              <TopicQA topicId={currentTopicId} topicTitle={topic.title} />
             )}
           </div>
         </div>

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -102,6 +102,28 @@ export default function TopicPage() {
   const isFinished = isTopicFinished(currentTopicId);
   const isLocked = !isEnrolled && !topic?.preview;
 
+  // Drip lock: topic has a future active_from date
+  const isDripLocked = isEnrolled && !!(topic as any)?.active_from && new Date((topic as any).active_from) > new Date();
+
+  // Prerequisite lock: previous topic in curriculum must be completed first
+  const currentTopicIndex = allTopics.findIndex((t) => t.id === currentTopicId);
+  const prerequisiteTopic = currentTopicIndex > 0 ? allTopics[currentTopicIndex - 1] : null;
+  const isPrerequisiteLocked = isEnrolled && !!prerequisiteTopic && !isTopicFinished(prerequisiteTopic.id);
+
+  // Compliance: video must be 90% watched / quiz must be passed before mark-complete
+  const [videoWatched, setVideoWatched] = useState(false);
+  const [quizPassed, setQuizPassed] = useState(false);
+
+  // Reset compliance flags when topic changes
+  useEffect(() => { setVideoWatched(false); setQuizPassed(false); }, [currentTopicId]);
+  // Already-finished topics don't need compliance re-check
+  const complianceMet = useMemo(() => {
+    if (isFinished) return true;
+    if (topic?.topicable_type === TopicType.Video) return videoWatched;
+    if (topic?.topicable_type === TopicType.GiftQuiz) return quizPassed;
+    return true;
+  }, [isFinished, topic?.topicable_type, videoWatched, quizPassed]);
+
   // Close user menu on outside click
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -291,9 +313,42 @@ export default function TopicPage() {
                   Go to course page
                 </Link>
               </div>
+            ) : isDripLocked ? (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="text-4xl mb-4">🕐</div>
+                <h2 className="text-xl font-bold text-[#04323e] mb-2">Content not yet available</h2>
+                <p className="text-[#555555]">
+                  This lesson unlocks on{" "}
+                  <span className="font-semibold">
+                    {new Date((topic as any).active_from).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}
+                  </span>.
+                </p>
+              </div>
+            ) : isPrerequisiteLocked ? (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="text-4xl mb-4">🔗</div>
+                <h2 className="text-xl font-bold text-[#04323e] mb-2">Complete the previous lesson first</h2>
+                <p className="text-[#555555] mb-6">
+                  You need to finish <span className="font-semibold">"{prerequisiteTopic!.title}"</span> before accessing this lesson.
+                </p>
+                <Link
+                  href={`/courses/${courseId}/topics/${prerequisiteTopic!.id}`}
+                  className="inline-block bg-[#1abc9c] hover:bg-[#15a288] text-white font-semibold px-8 py-3 rounded-full transition-colors"
+                >
+                  Go to previous lesson →
+                </Link>
+              </div>
             ) : (
               <>
-                <TopicContent topic={topic} onVideoEnded={handleVideoEnded} />
+                <TopicContent
+                  topic={topic}
+                  onVideoEnded={handleVideoEnded}
+                  onWatchedEnough={() => setVideoWatched(true)}
+                  onPass={() => setQuizPassed(true)}
+                />
+                {topic.topicable_type === TopicType.Video && !isFinished && !videoWatched && (
+                  <p className="mt-3 text-xs text-gray-400 text-center">Watch 90% of the video to mark this lesson complete.</p>
+                )}
                 <ExplainDifferentlyButton topicTitle={topic.title} />
               </>
             )}
@@ -353,10 +408,10 @@ export default function TopicPage() {
             )}
           </div>
 
-          {!isLocked && (
+          {!isLocked && !isDripLocked && !isPrerequisiteLocked && (
             <button
               onClick={handleMarkComplete}
-              disabled={isFinished || summaryLoading}
+              disabled={isFinished || summaryLoading || !complianceMet}
               className={`px-6 py-2.5 rounded-full font-semibold text-sm transition-colors ${
                 isFinished
                   ? "bg-[#1abc9c]/10 text-[#1abc9c] cursor-default"
@@ -367,6 +422,10 @@ export default function TopicPage() {
                 ? "Zusammenfassung…"
                 : isFinished
                 ? "✓ Completed"
+                : !complianceMet && topic.topicable_type === TopicType.Video
+                ? "Watch 90% to complete"
+                : !complianceMet && topic.topicable_type === TopicType.GiftQuiz
+                ? "Pass the quiz to continue"
                 : nextTopic
                 ? "Mark Complete & Continue →"
                 : "Mark as Complete"}

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -11,6 +11,7 @@ import { BookmarkButton } from "../../../../components/BookmarkButton";
 import { ExplainDifferentlyButton } from "../../../../components/ExplainDifferentlyButton";
 import { AiChatWidget } from "../../../../components/AiChatWidget";
 import { useToast } from "../../../../components/Toast";
+import { recordLessonCompletion } from "../../../../components/LearningGoalWidget";
 import type { API } from "@escolalms/sdk/lib";
 
 function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
@@ -125,6 +126,7 @@ export default function TopicPage() {
   const handleMarkComplete = useCallback(async () => {
     await sendProgress(courseId, [{ topic_id: currentTopicId, status: 1 }]);
     await fetchCourseProgress(courseId);
+    recordLessonCompletion();
 
     const nextPath = nextTopic
       ? `/courses/${courseId}/topics/${nextTopic.id}`

--- a/app/courses/[id]/topics/[topicId]/page.tsx
+++ b/app/courses/[id]/topics/[topicId]/page.tsx
@@ -27,6 +27,17 @@ function flattenTopics(lessons: API.Lesson[]): API.Topic[] {
   return result;
 }
 
+function findParentLesson(lessons: API.Lesson[], topicId: number): API.Lesson | null {
+  for (const lesson of lessons) {
+    if (lesson.topics?.some((t) => t.id === topicId)) return lesson;
+    if (lesson.lessons) {
+      const found = findParentLesson(lesson.lessons, topicId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 export default function TopicPage() {
   const { id, topicId } = useParams<{ id: string; topicId: string }>();
   const courseId = Number(id);
@@ -106,9 +117,11 @@ export default function TopicPage() {
   // Drip lock: topic has a future active_from date
   const isDripLocked = isEnrolled && !!(topic as any)?.active_from && new Date((topic as any).active_from) > new Date();
 
-  // Prerequisite lock: previous topic in curriculum must be completed first
-  const currentTopicIndex = allTopics.findIndex((t) => t.id === currentTopicId);
-  const prerequisiteTopic = currentTopicIndex > 0 ? allTopics[currentTopicIndex - 1] : null;
+  // Prerequisite lock: previous topic within the same lesson must be completed first
+  const parentLesson = useMemo(() => course?.lessons ? findParentLesson(course.lessons, currentTopicId) : null, [course, currentTopicId]);
+  const lessonTopics = parentLesson?.topics ?? [];
+  const currentTopicIndexInLesson = lessonTopics.findIndex((t) => t.id === currentTopicId);
+  const prerequisiteTopic = currentTopicIndexInLesson > 0 ? lessonTopics[currentTopicIndexInLesson - 1] : null;
   const isPrerequisiteLocked = isEnrolled && !!prerequisiteTopic && !isTopicFinished(prerequisiteTopic.id);
 
   // Compliance: video must be 90% watched / quiz must be passed before mark-complete

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { Nav } from "../components/Nav";
 import { ProgressBar } from "../components/ProgressBar";
+import { LearningGoalWidget } from "../components/LearningGoalWidget";
 import type { API } from "@escolalms/sdk/lib";
 
 function getProgress(item: API.CourseProgressItem): number {
@@ -52,9 +53,14 @@ export default function DashboardPage() {
     <>
       <Nav />
       <main className="max-w-5xl mx-auto px-4 py-12">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-[#04323e]">My courses</h1>
-          <p className="text-[#555555] mt-1">Welcome back, {user.value.first_name || user.value.email}</p>
+        <div className="mb-8 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-[#04323e]">My courses</h1>
+            <p className="text-[#555555] mt-1">Welcome back, {user.value.first_name || user.value.email}</p>
+          </div>
+          <div className="w-full sm:w-64 shrink-0">
+            <LearningGoalWidget />
+          </div>
         </div>
 
         {progress.loading && <p className="text-gray-500">Loading…</p>}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { Nav } from "../components/Nav";
 import { ProgressBar } from "../components/ProgressBar";
 import { LearningGoalWidget } from "../components/LearningGoalWidget";
+import { LearningNudge } from "../components/LearningNudge";
 import type { API } from "@escolalms/sdk/lib";
 
 function getProgress(item: API.CourseProgressItem): number {
@@ -52,6 +53,7 @@ export default function DashboardPage() {
   return (
     <>
       <Nav />
+      <LearningNudge />
       <main className="max-w-5xl mx-auto px-4 py-12">
         <div className="mb-8 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { Nav } from "../components/Nav";
 import { ProgressBar } from "../components/ProgressBar";
 import { LearningGoalWidget } from "../components/LearningGoalWidget";
 import { LearningNudge } from "../components/LearningNudge";
+import { GamificationWidget } from "../components/GamificationWidget";
 import type { API } from "@escolalms/sdk/lib";
 
 function getProgress(item: API.CourseProgressItem): number {
@@ -60,8 +61,9 @@ export default function DashboardPage() {
             <h1 className="text-3xl font-bold text-[#04323e]">My courses</h1>
             <p className="text-[#555555] mt-1">Welcome back, {user.value.first_name || user.value.email}</p>
           </div>
-          <div className="w-full sm:w-64 shrink-0">
+          <div className="w-full sm:w-64 shrink-0 space-y-3">
             <LearningGoalWidget />
+            <GamificationWidget />
           </div>
         </div>
 

--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -20,6 +20,7 @@ export interface Flashcard {
 const CARDS_KEY = "flashcards_v1";
 
 export function loadCards(): Flashcard[] {
+  if (typeof window === "undefined") return [];
   try {
     const raw = localStorage.getItem(CARDS_KEY);
     return raw ? JSON.parse(raw) : [];
@@ -27,6 +28,7 @@ export function loadCards(): Flashcard[] {
 }
 
 export function saveCards(cards: Flashcard[]) {
+  if (typeof window === "undefined") return;
   localStorage.setItem(CARDS_KEY, JSON.stringify(cards));
 }
 

--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Nav } from "../components/Nav";
+
+export interface Flashcard {
+  id: string;
+  topicId: number;
+  topicTitle: string;
+  question: string;
+  answer: string;
+  easeFactor: number;
+  interval: number;
+  repetitions: number;
+  nextReview: string; // ISO date
+}
+
+const CARDS_KEY = "flashcards_v1";
+
+export function loadCards(): Flashcard[] {
+  try {
+    const raw = localStorage.getItem(CARDS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+
+export function saveCards(cards: Flashcard[]) {
+  localStorage.setItem(CARDS_KEY, JSON.stringify(cards));
+}
+
+function sm2(card: Flashcard, quality: number): Flashcard {
+  let { easeFactor, interval, repetitions } = card;
+  if (quality < 3) {
+    repetitions = 0;
+    interval = 1;
+  } else {
+    if (repetitions === 0) interval = 1;
+    else if (repetitions === 1) interval = 6;
+    else interval = Math.round(interval * easeFactor);
+    repetitions++;
+    easeFactor = Math.max(1.3, easeFactor + 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
+  }
+  const nextReview = new Date(Date.now() + interval * 86400000).toISOString().split("T")[0];
+  return { ...card, easeFactor, interval, repetitions, nextReview };
+}
+
+const QUALITY_LABELS = ["Again", "Hard", "Okay", "Good", "Easy"];
+const QUALITY_STYLES = [
+  "border-red-300 text-red-600 hover:bg-red-50",
+  "border-orange-300 text-orange-600 hover:bg-orange-50",
+  "border-yellow-300 text-yellow-600 hover:bg-yellow-50",
+  "border-[#1abc9c] text-[#1abc9c] hover:bg-[#1abc9c]/5",
+  "border-blue-300 text-blue-600 hover:bg-blue-50",
+];
+
+export default function FlashcardsPage() {
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+  const [cards, setCards] = useState<Flashcard[]>([]);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const [sessionDone, setSessionDone] = useState(0);
+
+  useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    if (mounted) setCards(loadCards());
+  }, [mounted]);
+
+  const due = useMemo(() => {
+    const today = new Date().toISOString().split("T")[0];
+    return cards.filter((c) => c.nextReview <= today);
+  }, [cards]);
+
+  const current = due[0] ?? null;
+
+  const handleRate = useCallback((quality: number) => {
+    if (!current) return;
+    const updated = sm2(current, quality);
+    const next = cards.map((c) => (c.id === updated.id ? updated : c));
+    setCards(next);
+    saveCards(next);
+    setShowAnswer(false);
+    setSessionDone((n) => n + 1);
+  }, [current, cards]);
+
+  if (!mounted) return null;
+
+  const totalDue = due.length;
+  const remaining = totalDue - sessionDone;
+
+  return (
+    <>
+      <Nav />
+      <main className="max-w-2xl mx-auto px-4 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold text-[#04323e]">Flashcards</h1>
+          <span className="text-sm text-gray-400">{cards.length} Karten gesamt</span>
+        </div>
+
+        {cards.length === 0 && (
+          <div className="text-center py-20">
+            <p className="text-4xl mb-4">🃏</p>
+            <p className="text-[#555555] mb-2">Noch keine Flashcards erstellt.</p>
+            <p className="text-sm text-gray-400 mb-6">Öffne eine Lektion und klicke auf „Flashcards generieren".</p>
+            <Link href="/" className="inline-block bg-[#1abc9c] hover:bg-[#15a288] text-white font-semibold px-6 py-2.5 rounded-full transition-colors text-sm">
+              Kurse durchsuchen
+            </Link>
+          </div>
+        )}
+
+        {cards.length > 0 && totalDue === 0 && (
+          <div className="text-center py-20">
+            <p className="text-4xl mb-4">✅</p>
+            <p className="text-lg font-semibold text-[#04323e] mb-2">Alle Karten für heute gelernt!</p>
+            <p className="text-sm text-gray-400">Komm morgen wieder, um fällige Karten zu wiederholen.</p>
+          </div>
+        )}
+
+        {current && remaining > 0 && (
+          <div className="space-y-6">
+            <div className="flex items-center justify-between text-sm text-gray-400">
+              <span>Thema: {current.topicTitle}</span>
+              <span>{remaining} noch fällig</span>
+            </div>
+
+            <div
+              className="bg-white border border-gray-100 rounded-2xl shadow-sm p-8 min-h-48 flex flex-col justify-between cursor-pointer select-none"
+              onClick={() => setShowAnswer((v) => !v)}
+            >
+              <p className="text-sm font-semibold text-[#1abc9c] uppercase tracking-wide mb-3">Frage</p>
+              <p className="text-lg text-[#04323e] leading-relaxed">{current.question}</p>
+
+              {showAnswer ? (
+                <div className="mt-6 pt-6 border-t border-gray-100">
+                  <p className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Antwort</p>
+                  <p className="text-[#555555] leading-relaxed whitespace-pre-line">{current.answer}</p>
+                </div>
+              ) : (
+                <p className="mt-6 text-sm text-gray-300 text-center">Klicken zum Aufdecken</p>
+              )}
+            </div>
+
+            {showAnswer && (
+              <div className="grid grid-cols-5 gap-2">
+                {QUALITY_LABELS.map((label, q) => (
+                  <button
+                    key={q}
+                    onClick={() => handleRate(q)}
+                    className={`py-2 rounded-xl border text-xs font-semibold transition-colors ${QUALITY_STYLES[q]}`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {!showAnswer && (
+              <button
+                onClick={() => setShowAnswer(true)}
+                className="w-full bg-[#1abc9c] hover:bg-[#15a288] text-white font-semibold py-3 rounded-full transition-colors"
+              >
+                Antwort zeigen
+              </button>
+            )}
+          </div>
+        )}
+
+        {sessionDone > 0 && remaining === 0 && (
+          <div className="mt-8 text-center">
+            <p className="text-[#1abc9c] font-semibold">Session abgeschlossen — {sessionDone} Karten wiederholt!</p>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
 import { CourseCard } from "./components/CourseCard";
 import { Nav } from "./components/Nav";
+import { RecommendedCourses } from "./components/RecommendedCourses";
 import type { API } from "@escolalms/sdk/lib";
 
 export default function Home() {
@@ -91,6 +92,11 @@ export default function Home() {
     return new Set<number>();
   }, [myCourses]);
 
+  const enrolledTitles = useMemo(
+    () => allCourses.filter((c) => enrolledIds.has(c.id)).map((c) => c.title),
+    [allCourses, enrolledIds]
+  );
+
   function handleCategory(id: number | null) {
     setActiveCategoryId(id);
     setSearch("");
@@ -119,6 +125,14 @@ export default function Home() {
               My courses →
             </Link>
           </div>
+        )}
+
+        {loggedIn && enrolledTitles.length > 0 && (
+          <RecommendedCourses
+            enrolledTitles={enrolledTitles}
+            allCourses={allCourses}
+            enrolledIds={enrolledIds}
+          />
         )}
 
         <div className="flex items-center justify-between mb-4 gap-4">

--- a/app/tutor/page.tsx
+++ b/app/tutor/page.tsx
@@ -49,11 +49,11 @@ export default function TutorPage() {
 
     if (fetchMyAuthoredCourses) {
       tasks.push(
-        (fetchMyAuthoredCourses() as Promise<any>).then((res: any) => {
-          const data = res?.data ?? (ctx as any).authoredCourses?.value ?? [];
+        (fetchMyAuthoredCourses() as Promise<any>).then(() => {
+          const data: API.Course[] = (ctx as any).myAuthoredCourses?.list?.data ?? [];
           if (Array.isArray(data)) setCourses(data);
         }).catch(() => {
-          const fallback = (ctx as any).authoredCourses?.value;
+          const fallback: API.Course[] = (ctx as any).myAuthoredCourses?.list?.data ?? [];
           if (Array.isArray(fallback)) setCourses(fallback);
         })
       );

--- a/app/tutor/page.tsx
+++ b/app/tutor/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { EscolaLMSContext } from "@escolalms/sdk/lib/react/context";
+import { Nav } from "../components/Nav";
+import type { API } from "@escolalms/sdk/lib";
+
+function isTutor(u: API.UserAsProfile | null): boolean {
+  if (!u) return false;
+  const roles: unknown = (u as any).roles;
+  if (Array.isArray(roles)) {
+    return roles.some((r: any) =>
+      typeof r === "string"
+        ? r === "author" || r === "tutor"
+        : r?.name === "author" || r?.name === "tutor"
+    );
+  }
+  return false;
+}
+
+export default function TutorPage() {
+  const router = useRouter();
+  const ctx = useContext(EscolaLMSContext);
+  const { user, fetchTutorConsultations } = ctx;
+  const fetchMyAuthoredCourses = (ctx as any).fetchMyAuthoredCourses as
+    | ((params?: API.PaginationParams) => Promise<void>)
+    | undefined;
+
+  const [mounted, setMounted] = useState(false);
+  const [courses, setCourses] = useState<API.CourseListItem[]>([]);
+  const [consultations, setConsultations] = useState<API.AppointmentTerm[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [aiTip, setAiTip] = useState<string | null>(null);
+  const [tipLoading, setTipLoading] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    if (!user.value) { router.push("/"); return; }
+    if (!isTutor(user.value as API.UserAsProfile)) { router.push("/dashboard"); return; }
+
+    setLoading(true);
+    const tasks: Promise<unknown>[] = [];
+
+    if (fetchMyAuthoredCourses) {
+      tasks.push(
+        (fetchMyAuthoredCourses() as Promise<any>).then((res: any) => {
+          const data = res?.data ?? (ctx as any).authoredCourses?.value ?? [];
+          if (Array.isArray(data)) setCourses(data);
+        }).catch(() => {
+          const fallback = (ctx as any).authoredCourses?.value;
+          if (Array.isArray(fallback)) setCourses(fallback);
+        })
+      );
+    }
+
+    tasks.push(
+      fetchTutorConsultations().then((res: any) => {
+        const data = res?.data ?? [];
+        if (Array.isArray(data)) setConsultations(data);
+      }).catch(() => {})
+    );
+
+    Promise.all(tasks).finally(() => setLoading(false));
+  }, [mounted, user.value]);
+
+  const fetchAiTip = useCallback(async (courseTitles: string[]) => {
+    setTipLoading(true);
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          systemPrompt:
+            "Du bist ein Coaching-Experte für Online-Kurse. Gib einen konkreten, umsetzbaren Tipp für einen Kursersteller, um die Lernmotivation seiner Teilnehmer zu steigern. Antworte auf Deutsch in 2-3 Sätzen.",
+          messages: [
+            {
+              role: "user",
+              content: courseTitles.length
+                ? `Meine Kurse: ${courseTitles.join(", ")}. Was kann ich verbessern?`
+                : "Ich erstelle Online-Kurse. Was kann ich verbessern?",
+            },
+          ],
+        }),
+      });
+      const data = await res.json();
+      if (data.content) setAiTip(data.content);
+    } catch {}
+    setTipLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!loading && courses.length > 0 && !aiTip && !tipLoading) {
+      fetchAiTip(courses.map((c) => c.title));
+    }
+  }, [loading, courses]);
+
+  if (!mounted) return null;
+  if (!user.value || !isTutor(user.value as API.UserAsProfile)) return null;
+
+  const u = user.value as API.UserAsProfile;
+
+  return (
+    <>
+      <Nav />
+      <main className="max-w-5xl mx-auto px-4 py-12">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-[#04323e]">Tutor-Dashboard</h1>
+          <p className="text-[#555555] mt-1">Willkommen, {u.first_name || u.email}</p>
+        </div>
+
+        {(aiTip || tipLoading) && (
+          <div className="mb-8 rounded-xl border border-[#1abc9c]/30 bg-[#1abc9c]/5 px-5 py-4">
+            <p className="text-xs font-semibold text-[#1abc9c] mb-1">KI-Coaching-Tipp</p>
+            {tipLoading ? (
+              <p className="text-sm text-gray-400 animate-pulse">KI generiert Tipp…</p>
+            ) : (
+              <p className="text-sm text-[#04323e] leading-relaxed">{aiTip}</p>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* Authored courses */}
+          <section>
+            <h2 className="text-lg font-semibold text-[#04323e] mb-4">Meine Kurse</h2>
+            {loading && <p className="text-sm text-gray-400">Lädt…</p>}
+            {!loading && courses.length === 0 && (
+              <p className="text-sm text-gray-400">Keine Kurse gefunden.</p>
+            )}
+            <ul className="space-y-3">
+              {courses.map((course) => (
+                <li key={course.id} className="bg-white border border-gray-100 rounded-xl p-4 shadow-sm flex gap-4 items-center">
+                  {course.image_url ? (
+                    <img
+                      src={course.image_url}
+                      alt={course.title}
+                      className="w-16 h-12 object-cover rounded-lg shrink-0"
+                    />
+                  ) : (
+                    <div className="w-16 h-12 bg-gray-100 rounded-lg shrink-0" />
+                  )}
+                  <div className="min-w-0">
+                    <Link
+                      href={`/courses/${course.id}`}
+                      className="text-sm font-semibold text-[#04323e] hover:text-[#1abc9c] transition-colors line-clamp-1"
+                    >
+                      {course.title}
+                    </Link>
+                    {(course as any).users_count !== undefined && (
+                      <p className="text-xs text-gray-400 mt-0.5">
+                        {(course as any).users_count} Teilnehmer
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Consultation bookings */}
+          <section>
+            <h2 className="text-lg font-semibold text-[#04323e] mb-4">Buchungsanfragen</h2>
+            {loading && <p className="text-sm text-gray-400">Lädt…</p>}
+            {!loading && consultations.length === 0 && (
+              <p className="text-sm text-gray-400">Keine offenen Buchungsanfragen.</p>
+            )}
+            <ul className="space-y-3">
+              {consultations.map((term, i) => (
+                <li
+                  key={(term as any).id ?? i}
+                  className="bg-white border border-gray-100 rounded-xl p-4 shadow-sm"
+                >
+                  <p className="text-sm font-semibold text-[#04323e]">
+                    {(term as any).consultation?.title ?? "Konsultation"}
+                  </p>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    {(term as any).date
+                      ? new Date((term as any).date).toLocaleString("de-DE")
+                      : "Datum ausstehend"}
+                  </p>
+                  <p className={`text-xs mt-1 font-medium ${
+                    (term as any).status === "approved"
+                      ? "text-[#1abc9c]"
+                      : (term as any).status === "rejected"
+                      ? "text-red-500"
+                      : "text-amber-500"
+                  }`}>
+                    {(term as any).status ?? "ausstehend"}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

### AI / Coaching (previously shipped)
- **#57** KI-Feedback auf Projektabgaben · **#45** Lernziele · **#42** KI-Empfehlungen · **#54** Tutor-Dashboard · **#56** Q&A per Lektion · **#47** Flashcard Generator (SM-2) · **#53** Proaktive Lern-Nudges

### Sprint 1 — Core Learning Gates
- **#2 Drip Content**: topics with future `active_from` show "unlocks on [date]" screen
- **#11 Prerequisites**: enrolled students must complete the previous topic first
- **#12/#62 Course Compliance**: video gated at 90% watch time; quiz gated on pass (≥60%)

### Sprint 2 — Engagement
- **#16 In-App Notifications**: Bell icon in Nav, polls SDK every 60s, unread badge, mark-as-read / mark-all-read
- **#17 Gamification**: XP points (10/lesson), 5 badge milestones displayed on dashboard with progress bar to next badge

## Test plan
- [ ] Navigate to a drip-locked topic → "unlocks on" screen shown
- [ ] Skip a lesson while enrolled → prerequisite lock screen shown
- [ ] Video topic: Mark Complete disabled until 90% watched
- [ ] Quiz topic: Mark Complete disabled until quiz passed (≥60%)
- [ ] Bell icon shows unread count; dropdown lists notifications; click marks as read
- [ ] Complete a lesson → XP increments; badge earned at threshold shown on dashboard
- [ ] `npx tsc --noEmit` → no errors

Closes #2
Closes #11
Closes #12
Closes #16
Closes #17
Closes #42
Closes #45
Closes #47
Closes #53
Closes #54
Closes #56
Closes #57

https://claude.ai/code/session_01YJuSA3d5V78Y7KuCVDSrKP